### PR TITLE
Add .NET 9 MAUI MvvmCross placeholder app

### DIFF
--- a/MvvmCrossMauiApp.sln
+++ b/MvvmCrossMauiApp.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvvmCrossMauiApp", "MvvmCrossMauiApp\MvvmCrossMauiApp.csproj", "{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Debug|x64.Build.0 = Debug|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Debug|x86.Build.0 = Debug|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Release|x64.ActiveCfg = Release|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Release|x64.Build.0 = Release|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Release|x86.ActiveCfg = Release|Any CPU
+		{2B7FB2D8-B7C0-43F0-87A9-1B34CCD260FE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/MvvmCrossMauiApp/App.cs
+++ b/MvvmCrossMauiApp/App.cs
@@ -1,0 +1,13 @@
+using MvvmCross.ViewModels;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp;
+
+// MvvmCross application entry point. Registers the initial navigation.
+public class App : MvxApplication
+{
+    public override void Initialize()
+    {
+        RegisterAppStart<SplashViewModel>();
+    }
+}

--- a/MvvmCrossMauiApp/MauiMvxSetup.cs
+++ b/MvvmCrossMauiApp/MauiMvxSetup.cs
@@ -1,0 +1,14 @@
+using MvvmCross.IoC;
+using MvvmCross.Platforms.Maui.Core;
+
+namespace MvvmCrossMauiApp;
+
+// Bootstraps MvvmCross inside .NET MAUI
+public class MauiMvxSetup : MvxMauiSetup<App>
+{
+    protected override void RegisterDependencies(IMvxIoCProvider iocProvider)
+    {
+        base.RegisterDependencies(iocProvider);
+        // register app services here
+    }
+}

--- a/MvvmCrossMauiApp/MauiProgram.cs
+++ b/MvvmCrossMauiApp/MauiProgram.cs
@@ -1,0 +1,17 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+using MvvmCross.Platforms.Maui.Core;
+
+namespace MvvmCrossMauiApp;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .UseMauiMvx<MauiMvxSetup>();
+        return builder.Build();
+    }
+}

--- a/MvvmCrossMauiApp/MvvmCrossMauiApp.csproj
+++ b/MvvmCrossMauiApp/MvvmCrossMauiApp.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MvvmCross" Version="9.4.0" />
+    <PackageReference Include="MvvmCross.Maui" Version="9.4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <MauiIcon Include="Resources/appicon.svg" />
+    <MauiSplashScreen Include="Resources/splash.svg" />
+    <Compile Update="**/*.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="**/*.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+</Project>

--- a/MvvmCrossMauiApp/Platforms/Android/AndroidManifest.xml
+++ b/MvvmCrossMauiApp/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application android:allowBackup="true" android:label="MvvmCrossMauiApp">
+        <activity android:name="com.microsoft.maui.MauiAppCompatActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="myapp" android:host="details" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/MvvmCrossMauiApp/Platforms/iOS/Info.plist
+++ b/MvvmCrossMauiApp/Platforms/iOS/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.company.mvvmcrossmauiapp</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>myapp</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/MvvmCrossMauiApp/README.md
+++ b/MvvmCrossMauiApp/README.md
@@ -1,0 +1,39 @@
+# MvvmCrossMauiApp
+
+Placeholder .NET 9 MAUI app using MvvmCross for navigation and MVVM.
+
+## Prerequisites
+- [.NET 9 SDK](https://dotnet.microsoft.com/)
+- .NET MAUI workloads for Android and iOS (`dotnet workload install maui`)
+- Android/iOS tooling as required by MAUI
+
+## Build and Run
+```
+# Android
+dotnet build -t:Run -f net9.0-android MvvmCrossMauiApp.csproj
+
+# iOS
+dotnet build -t:Run -f net9.0-ios MvvmCrossMauiApp.csproj
+```
+
+## Navigation
+- SplashView -> automatically navigates to LoginView.
+- LoginView buttons navigate to HomeView or RegisterView.
+- RegisterView closes back to LoginView.
+- HomeView navigates to Details, Settings, About, or logs out.
+- DetailsView accepts an `ItemId` parameter and can open SubDetails or go back.
+- Back commands call `_navigation.Close(this)` and hardware back uses `CanClose` overrides.
+
+### Deep Link
+The app exposes a deep link to `DetailsView` with an `ItemId`.
+
+- Android test:
+  ```bash
+  adb shell am start -a android.intent.action.VIEW -d "myapp://details/42"
+  ```
+- iOS test (simulator):
+  ```bash
+  xcrun simctl openurl booted "myapp://details/42"
+  ```
+
+The parameter is bound in `DetailsViewModel`.

--- a/MvvmCrossMauiApp/Resources/appicon.svg
+++ b/MvvmCrossMauiApp/Resources/appicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#512BD4"/><text x="50" y="55" font-size="50" text-anchor="middle" fill="white">M</text></svg>

--- a/MvvmCrossMauiApp/Resources/splash.svg
+++ b/MvvmCrossMauiApp/Resources/splash.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#512BD4"/><text x="50" y="55" font-size="30" text-anchor="middle" fill="white">Splash</text></svg>

--- a/MvvmCrossMauiApp/ViewModels/AboutViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/AboutViewModel.cs
@@ -1,0 +1,20 @@
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+public class AboutViewModel : MvxViewModel
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public AboutViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+        BackCommand = new MvxAsyncCommand(() => _navigation.Close(this));
+    }
+
+    public IMvxAsyncCommand BackCommand { get; }
+
+    public override Task<bool> CanClose() => Task.FromResult(true);
+}

--- a/MvvmCrossMauiApp/ViewModels/DetailsViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/DetailsViewModel.cs
@@ -1,0 +1,31 @@
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+// Deep link route: myapp://details/{ItemId}
+[MvvmCross.Navigation.MvxRoute("details/{ItemId}")]
+public class DetailsViewModel : MvxViewModel<ItemParams>
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public DetailsViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+        OpenSubDetailsCommand = new MvxAsyncCommand(() => _navigation.Navigate<SubDetailsViewModel>());
+        BackCommand = new MvxAsyncCommand(() => _navigation.Close(this));
+    }
+
+    public int ItemId { get; private set; }
+
+    public IMvxAsyncCommand OpenSubDetailsCommand { get; }
+    public IMvxAsyncCommand BackCommand { get; }
+
+    public override void Prepare(ItemParams parameter)
+    {
+        ItemId = parameter.ItemId;
+    }
+
+    public override Task<bool> CanClose() => Task.FromResult(true);
+}

--- a/MvvmCrossMauiApp/ViewModels/HomeViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/HomeViewModel.cs
@@ -1,0 +1,26 @@
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+public class HomeViewModel : MvxViewModel
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public HomeViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+        ShowDetailsCommand = new MvxAsyncCommand(() => _navigation.Navigate<DetailsViewModel, ItemParams>(new ItemParams { ItemId = 42 }));
+        ShowSettingsCommand = new MvxAsyncCommand(() => _navigation.Navigate<SettingsViewModel>());
+        ShowAboutCommand = new MvxAsyncCommand(() => _navigation.Navigate<AboutViewModel>());
+        LogoutCommand = new MvxAsyncCommand(() => _navigation.Navigate<LoginViewModel>(new MvxNavigationOptions { ClearNavigationStack = true }));
+    }
+
+    public IMvxAsyncCommand ShowDetailsCommand { get; }
+    public IMvxAsyncCommand ShowSettingsCommand { get; }
+    public IMvxAsyncCommand ShowAboutCommand { get; }
+    public IMvxAsyncCommand LogoutCommand { get; }
+
+    public override Task<bool> CanClose() => Task.FromResult(true);
+}

--- a/MvvmCrossMauiApp/ViewModels/ItemParams.cs
+++ b/MvvmCrossMauiApp/ViewModels/ItemParams.cs
@@ -1,0 +1,7 @@
+namespace MvvmCrossMauiApp.ViewModels;
+
+// Parameter object passed to DetailsViewModel during navigation
+public class ItemParams
+{
+    public int ItemId { get; set; }
+}

--- a/MvvmCrossMauiApp/ViewModels/LoginViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/LoginViewModel.cs
@@ -1,0 +1,22 @@
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+public class LoginViewModel : MvxViewModel
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public LoginViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+        GoHomeCommand = new MvxAsyncCommand(() => _navigation.Navigate<HomeViewModel>(new MvxNavigationOptions { ClearNavigationStack = true }));
+        GoRegisterCommand = new MvxAsyncCommand(() => _navigation.Navigate<RegisterViewModel>());
+    }
+
+    public IMvxAsyncCommand GoHomeCommand { get; }
+    public IMvxAsyncCommand GoRegisterCommand { get; }
+
+    public override Task<bool> CanClose() => Task.FromResult(true);
+}

--- a/MvvmCrossMauiApp/ViewModels/RegisterViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/RegisterViewModel.cs
@@ -1,0 +1,20 @@
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+public class RegisterViewModel : MvxViewModel
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public RegisterViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+        BackCommand = new MvxAsyncCommand(() => _navigation.Close(this));
+    }
+
+    public IMvxAsyncCommand BackCommand { get; }
+
+    public override Task<bool> CanClose() => Task.FromResult(true);
+}

--- a/MvvmCrossMauiApp/ViewModels/SettingsViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,20 @@
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+public class SettingsViewModel : MvxViewModel
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public SettingsViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+        BackCommand = new MvxAsyncCommand(() => _navigation.Close(this));
+    }
+
+    public IMvxAsyncCommand BackCommand { get; }
+
+    public override Task<bool> CanClose() => Task.FromResult(true);
+}

--- a/MvvmCrossMauiApp/ViewModels/SplashViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/SplashViewModel.cs
@@ -1,0 +1,21 @@
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+public class SplashViewModel : MvxViewModel
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public SplashViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+    }
+
+    public override async Task Initialize()
+    {
+        await base.Initialize();
+        // Replace the navigation stack with Login
+        await _navigation.Navigate<LoginViewModel>(new MvxNavigationOptions { ClearNavigationStack = true });
+    }
+}

--- a/MvvmCrossMauiApp/ViewModels/SubDetailsViewModel.cs
+++ b/MvvmCrossMauiApp/ViewModels/SubDetailsViewModel.cs
@@ -1,0 +1,20 @@
+using MvvmCross.Commands;
+using MvvmCross.Navigation;
+using MvvmCross.ViewModels;
+
+namespace MvvmCrossMauiApp.ViewModels;
+
+public class SubDetailsViewModel : MvxViewModel
+{
+    private readonly IMvxNavigationService _navigation;
+
+    public SubDetailsViewModel(IMvxNavigationService navigation)
+    {
+        _navigation = navigation;
+        BackCommand = new MvxAsyncCommand(() => _navigation.Close(this));
+    }
+
+    public IMvxAsyncCommand BackCommand { get; }
+
+    public override Task<bool> CanClose() => Task.FromResult(true);
+}

--- a/MvvmCrossMauiApp/Views/AboutView.xaml
+++ b/MvvmCrossMauiApp/Views/AboutView.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.AboutView"
+                    x:DataType="viewModels:AboutViewModel">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="About" FontSize="24"/>
+        <Button Text="Back" Command="{Binding BackCommand}"/>
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/AboutView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/AboutView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class AboutView : MvxContentPage<AboutViewModel>
+{
+    public AboutView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MvvmCrossMauiApp/Views/DetailsView.xaml
+++ b/MvvmCrossMauiApp/Views/DetailsView.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.DetailsView"
+                    x:DataType="viewModels:DetailsViewModel">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="Details" FontSize="24"/>
+        <Label Text="{Binding ItemId, StringFormat='ItemId: {0}'}"/>
+        <Button Text="Open SubDetails" Command="{Binding OpenSubDetailsCommand}"/>
+        <Button Text="Back" Command="{Binding BackCommand}"/>
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/DetailsView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/DetailsView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class DetailsView : MvxContentPage<DetailsViewModel>
+{
+    public DetailsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MvvmCrossMauiApp/Views/HomeView.xaml
+++ b/MvvmCrossMauiApp/Views/HomeView.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.HomeView"
+                    x:DataType="viewModels:HomeViewModel">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="Home" FontSize="24"/>
+        <Button Text="Details" Command="{Binding ShowDetailsCommand}"/>
+        <Button Text="Settings" Command="{Binding ShowSettingsCommand}"/>
+        <Button Text="About" Command="{Binding ShowAboutCommand}"/>
+        <Button Text="Logout" Command="{Binding LogoutCommand}"/>
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/HomeView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/HomeView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class HomeView : MvxContentPage<HomeViewModel>
+{
+    public HomeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MvvmCrossMauiApp/Views/LoginView.xaml
+++ b/MvvmCrossMauiApp/Views/LoginView.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.LoginView"
+                    x:DataType="viewModels:LoginViewModel">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="Login" FontSize="24"/>
+        <Button Text="Go to Home" Command="{Binding GoHomeCommand}"/>
+        <Button Text="Go to Register" Command="{Binding GoRegisterCommand}"/>
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/LoginView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/LoginView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class LoginView : MvxContentPage<LoginViewModel>
+{
+    public LoginView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MvvmCrossMauiApp/Views/RegisterView.xaml
+++ b/MvvmCrossMauiApp/Views/RegisterView.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.RegisterView"
+                    x:DataType="viewModels:RegisterViewModel">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="Register" FontSize="24"/>
+        <Button Text="Back to Login" Command="{Binding BackCommand}"/>
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/RegisterView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/RegisterView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class RegisterView : MvxContentPage<RegisterViewModel>
+{
+    public RegisterView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MvvmCrossMauiApp/Views/SettingsView.xaml
+++ b/MvvmCrossMauiApp/Views/SettingsView.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.SettingsView"
+                    x:DataType="viewModels:SettingsViewModel">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="Settings" FontSize="24"/>
+        <Button Text="Back" Command="{Binding BackCommand}"/>
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/SettingsView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/SettingsView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class SettingsView : MvxContentPage<SettingsViewModel>
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MvvmCrossMauiApp/Views/SplashView.xaml
+++ b/MvvmCrossMauiApp/Views/SplashView.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.SplashView"
+                    x:DataType="viewModels:SplashViewModel">
+    <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center">
+        <Label Text="Splash" FontSize="24" />
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/SplashView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/SplashView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class SplashView : MvxContentPage<SplashViewModel>
+{
+    public SplashView()
+    {
+        InitializeComponent();
+    }
+}

--- a/MvvmCrossMauiApp/Views/SubDetailsView.xaml
+++ b/MvvmCrossMauiApp/Views/SubDetailsView.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<mvx:MvxContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:mvx="clr-namespace:MvvmCross.Maui.Views;assembly=MvvmCross.Maui"
+                    xmlns:viewModels="clr-namespace:MvvmCrossMauiApp.ViewModels"
+                    x:Class="MvvmCrossMauiApp.Views.SubDetailsView"
+                    x:DataType="viewModels:SubDetailsViewModel">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="SubDetails" FontSize="24"/>
+        <Button Text="Back" Command="{Binding BackCommand}"/>
+    </VerticalStackLayout>
+</mvx:MvxContentPage>

--- a/MvvmCrossMauiApp/Views/SubDetailsView.xaml.cs
+++ b/MvvmCrossMauiApp/Views/SubDetailsView.xaml.cs
@@ -1,0 +1,12 @@
+using MvvmCross.Maui.Views;
+using MvvmCrossMauiApp.ViewModels;
+
+namespace MvvmCrossMauiApp.Views;
+
+public partial class SubDetailsView : MvxContentPage<SubDetailsViewModel>
+{
+    public SubDetailsView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold .NET 9 MAUI app using MvvmCross navigation and MVVM patterns
- add placeholder views/viewmodels with navigation, deep-linking, and back handling
- include Android/iOS manifests, MAUI resources, and README instructions

## Testing
- `dotnet build MvvmCrossMauiApp/MvvmCrossMauiApp.csproj -f net9.0-android` *(fails: InternalLoggerException)*
- `dotnet build MvvmCrossMauiApp/MvvmCrossMauiApp.csproj -f net9.0-ios --no-restore --verbosity minimal` *(fails: InternalLoggerException)*

------
https://chatgpt.com/codex/tasks/task_e_68a33635943c8320b90c4507c0c1fff0