### PR TITLE
Add flyout Shell with icon font menu

### DIFF
--- a/MauiSplashTemplate/AppShell.xaml
+++ b/MauiSplashTemplate/AppShell.xaml
@@ -4,11 +4,26 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:MauiSplashTemplate"
-    Shell.FlyoutBehavior="Disabled">
+    xmlns:mi="http://www.aathifmahir.com/dotnet/2022/maui/icons">
 
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
+    <FlyoutItem Title="Home">
+        <ShellContent
+            Title="Home"
+            ContentTemplate="{DataTemplate local:MainPage}">
+            <ShellContent.Icon>
+                <FontImageSource Glyph="{mi:Material Icon=Home}" />
+            </ShellContent.Icon>
+        </ShellContent>
+    </FlyoutItem>
+
+    <FlyoutItem Title="Profile">
+        <ShellContent
+            Title="Profile"
+            ContentTemplate="{DataTemplate local:ProfilePage}">
+            <ShellContent.Icon>
+                <FontImageSource Glyph="{mi:Material Icon=Person}" />
+            </ShellContent.Icon>
+        </ShellContent>
+    </FlyoutItem>
 
 </Shell>

--- a/MauiSplashTemplate/AppShell.xaml.cs
+++ b/MauiSplashTemplate/AppShell.xaml.cs
@@ -1,9 +1,10 @@
-﻿namespace MauiSplashTemplate;
+namespace MauiSplashTemplate;
 
 public partial class AppShell : Shell
 {
     public AppShell()
     {
         InitializeComponent();
+        Routing.RegisterRoute(nameof(ProfilePage), typeof(ProfilePage));
     }
 }

--- a/MauiSplashTemplate/MauiProgram.cs
+++ b/MauiSplashTemplate/MauiProgram.cs
@@ -1,4 +1,7 @@
 using MauiIcons;
+using MauiIcons.Material;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
 
 namespace MauiSplashTemplate;
 

--- a/MauiSplashTemplate/MauiProgram.cs
+++ b/MauiSplashTemplate/MauiProgram.cs
@@ -1,13 +1,16 @@
-﻿namespace MauiSplashTemplate;
+using MauiIcons;
+
+namespace MauiSplashTemplate;
 
 public static class MauiProgram
 {
-	public static MauiApp CreateMauiApp()
-	{
-		var builder = MauiApp.CreateBuilder();
-                builder
-                        .UseMauiApp<App>();
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .UseMaterialMauiIcons();
 
-                return builder.Build();
-        }
+        return builder.Build();
+    }
 }

--- a/MauiSplashTemplate/MauiSplashTemplate.csproj
+++ b/MauiSplashTemplate/MauiSplashTemplate.csproj
@@ -38,8 +38,12 @@
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <None Remove="Platforms\Android\Resources\Splash\splash.png" />
-	</ItemGroup>
+        <ItemGroup>
+          <None Remove="Platforms\Android\Resources\Splash\splash.png" />
+        </ItemGroup>
+
+        <ItemGroup>
+                <PackageReference Include="AathifMahir.Maui.MauiIcons.Material" Version="4.0.0" />
+        </ItemGroup>
 
 </Project>

--- a/MauiSplashTemplate/ProfilePage.xaml
+++ b/MauiSplashTemplate/ProfilePage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="MauiSplashTemplate.ProfilePage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    Title="Profile">
+    <VerticalStackLayout Padding="20">
+        <Label Text="Profile Page" HorizontalOptions="Center" VerticalOptions="Center" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/MauiSplashTemplate/ProfilePage.xaml.cs
+++ b/MauiSplashTemplate/ProfilePage.xaml.cs
@@ -1,0 +1,9 @@
+namespace MauiSplashTemplate;
+
+public partial class ProfilePage : ContentPage
+{
+    public ProfilePage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- enable Shell flyout navigation with Home and Profile pages
- use Material icon font via NuGet and register Material icons
- add simple ProfilePage

## Testing
- `dotnet build` *(fails: The target platform identifier android was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a44b62cda48320af692274bb04362a